### PR TITLE
Include betas of Accessories 1.1.0 as acceptable versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,4 +40,4 @@ mod_authors=mageowl
 mod_description=Keep your weapons and armor after you die.
 # Specific version of Accessories to use in development
 accessories_version=1.1.0-beta.53+1.21.1
-accessories_version_range=[1.1,)
+accessories_version_range=[1.1.0-beta,)


### PR DESCRIPTION
Fixes Neoforge complaining about Accessories being in a not-high-enough version because it considers stable versions higher than betas.